### PR TITLE
Update DataMapping member types.

### DIFF
--- a/src/unforge/ComplexTypes/DataForgeDataMapping.cs
+++ b/src/unforge/ComplexTypes/DataForgeDataMapping.cs
@@ -16,8 +16,13 @@ namespace unforge
         public DataForgeDataMapping(DataForge documentRoot)
             : base(documentRoot)
         {
-            this.StructCount = this._br.ReadUInt32();
-            this.StructIndex = this._br.ReadUInt32();
+			if(this.DocumentRoot.FileVersion >= 5) {
+				this.StructCount = this._br.ReadUInt32();
+            	this.StructIndex = this._br.ReadUInt32();
+			} else {
+            	this.StructCount = this._br.ReadUInt16();
+            	this.StructIndex = this._br.ReadUInt16();
+			}
             this.NameOffset = documentRoot.StructDefinitionTable[this.StructIndex].NameOffset;
         }
 

--- a/src/unforge/ComplexTypes/DataForgeDataMapping.cs
+++ b/src/unforge/ComplexTypes/DataForgeDataMapping.cs
@@ -8,16 +8,16 @@ namespace unforge
 {
     public class DataForgeDataMapping : _DataForgeSerializable
     {
-        public UInt16 StructIndex { get; set; }
-        public UInt16 StructCount { get; set; }
+        public UInt32 StructIndex { get; set; }
+        public UInt32 StructCount { get; set; }
         public UInt32 NameOffset { get; set; }
         public String Name { get { return this.DocumentRoot.ValueMap[this.NameOffset]; } }
 
         public DataForgeDataMapping(DataForge documentRoot)
             : base(documentRoot)
         {
-            this.StructCount = this._br.ReadUInt16();
-            this.StructIndex = this._br.ReadUInt16();
+            this.StructCount = this._br.ReadUInt32();
+            this.StructIndex = this._br.ReadUInt32();
             this.NameOffset = documentRoot.StructDefinitionTable[this.StructIndex].NameOffset;
         }
 


### PR DESCRIPTION
Update DataForgeDataMapping StructIndex and StructCount types and reads for new structure in Datacore version 5.

Needs legacy support for v4, please ignore for now, and do not merge.