### PR TITLE
Add logging infrastructure, fix DataForge extraction bugs, and add unsocpak tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,30 @@ CryXML is a basic serialized XML format which `unforge.exe` is able to deseriali
 Inside the p4k file, there is also a `game.dcb` file, which is a bespoke database format, with similarities to CryXML.
 
 This is the product of what is known internally as "DataForge", and is also able to be converted/extracted using the `unforge.exe` tool.
+
+# unsocpak - Batch .socpak Extractor
+
+Star Citizen uses `.socpak` files as compressed archives for various game assets. While these are standard zip files that can be extracted with any zip tool, `unsocpak.exe` is optimized for batch extraction of multiple socpak files at once.
+
+## Usage:
+
+```
+unsocpak.exe [options] <path>
+```
+
+## Options:
+
+- `-v, --verbose` - Enable verbose output (show all operations)
+- `-l, --log` - Write extraction log to file (unsocpak.log)
+- `-o, --overwrite` - Overwrite existing files (default: skip)
+
+## Examples:
+
+```bash
+unsocpak.exe file.socpak              # Extract single file
+unsocpak.exe *.socpak                 # Extract all socpak files in current directory
+unsocpak.exe /path/to/dir             # Extract all socpak files recursively in a directory
+unsocpak.exe -v -o /path/to/dir       # Verbose extraction with overwrite
+```
+
+The tool recursively finds all `.socpak` files in the specified path and extracts them in place, providing progress feedback and a summary of the extraction process.

--- a/src/unforge.cli/Program.cs
+++ b/src/unforge.cli/Program.cs
@@ -12,18 +12,30 @@ namespace unforge.cli
 			System.Threading.Thread.CurrentThread.CurrentCulture = ci;
 			System.Threading.Thread.CurrentThread.CurrentUICulture = ci;
 
+			// Parse command-line options
+			var verbose = args.Any(a => a == "-v" || a == "--verbose");
+			var logToFile = args.Any(a => a == "-l" || a == "--log");
+			var inputArgs = args.Where(a => !a.StartsWith("-")).ToArray();
 
-			if (args.Length == 0)
+			// Configure logging
+			DataForgeLogger.Instance.IsEnabled = true;
+			DataForgeLogger.Instance.VerboseMode = verbose;
+
+			if (inputArgs.Length == 0)
 			{
-				args = new String[] { "game.dcb" };
-				// args = new String[] { "wrld.xml" };
-				// args = new String[] { "Data" };
-				// args = new String[] { @"S:\Mods\BuildXPLOR\archive-3.0\661655\Data\game.dcb" };
+				inputArgs = new String[] { "game.dcb" };
+				// inputArgs = new String[] { "wrld.xml" };
+				// inputArgs = new String[] { "Data" };
+				// inputArgs = new String[] { @"S:\Mods\BuildXPLOR\archive-3.0\661655\Data\game.dcb" };
 			}
 
-			if (args.Length < 1 || args.Length > 1)
+			if (inputArgs.Length < 1 || inputArgs.Length > 1)
 			{
-				Console.WriteLine("Usage: unforge.exe [infile]");
+				Console.WriteLine("Usage: unforge.exe [options] [infile]");
+				Console.WriteLine();
+				Console.WriteLine("Options:");
+				Console.WriteLine("  -v, --verbose    Enable verbose output (show errors in console)");
+				Console.WriteLine("  -l, --log        Write errors to a log file (infile.log)");
 				Console.WriteLine();
 				Console.WriteLine("Converts any Star Citizen binary file into an actual XML file.");
 				Console.WriteLine("CryXml files (.xml) are saved as .raw in the original location.");
@@ -36,24 +48,44 @@ namespace unforge.cli
 				return;
 			}
 
-			if ((args.Length > 0) && Directory.Exists(args[0]))
+			var inputPath = inputArgs[0];
+
+			if (Directory.Exists(inputPath))
 			{
-				foreach (var file in Directory.GetFiles(args[0], "*.*", SearchOption.AllDirectories))
+				foreach (var file in Directory.GetFiles(inputPath, "*.*", SearchOption.AllDirectories))
 				{
 					if (new String[] { "ini", "txt" }.Contains(Path.GetExtension(file), StringComparer.InvariantCultureIgnoreCase)) continue;
 
 					try
 					{
-						Console.WriteLine("Converting {0}", file.Replace(args[0], ""));
+						Console.WriteLine("Converting {0}", file.Replace(inputPath, ""));
 
 						Smelter.Instance.Smelt(file);
 					}
-					catch (Exception) { }
+					catch (Exception ex)
+					{
+						DataForgeLogger.Instance.LogError(
+							message: $"Failed to convert file",
+							recordPath: file,
+							exception: ex);
+					}
 				}
 			}
 			else
 			{
-				Smelter.Instance.Smelt(args[0]);
+				Smelter.Instance.Smelt(inputPath);
+			}
+
+			// Output summary
+			Console.WriteLine();
+			Console.WriteLine(DataForgeLogger.Instance.GetSummary());
+
+			// Save log file if requested
+			if (logToFile)
+			{
+				var logPath = Path.ChangeExtension(inputPath, "log");
+				DataForgeLogger.Instance.SaveToFile(logPath);
+				Console.WriteLine($"Log saved to: {logPath}");
 			}
 		}
 	}
@@ -74,6 +106,8 @@ namespace unforge.cli
 				{
 					if (Path.GetExtension(path) == ".dcb")
 					{
+						DataForgeLogger.Instance.LogInfo($"Processing DCB file: {path}");
+
 						using var fileStream = File.OpenRead(path);
 						var df = new DataForge(fileStream);
 						df.Save(Path.ChangeExtension(path, "xml"));
@@ -97,13 +131,18 @@ namespace unforge.cli
 						}
 						else
 						{
-							Console.WriteLine("{0} already in XML format", path);
+							DataForgeLogger.Instance.LogDebug($"{path} already in XML format");
 						}
 					}
 				}
 			}
 			catch (Exception ex)
 			{
+				DataForgeLogger.Instance.LogError(
+					message: $"Error converting file",
+					recordPath: path,
+					exception: ex);
+
 				Console.WriteLine("Error converting {0}: {1}", path, ex.Message);
 			}
 		}

--- a/src/unforge/ComplexTypes/DataForgeRecordDefinition.cs
+++ b/src/unforge/ComplexTypes/DataForgeRecordDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml;
 
 namespace unforge
@@ -11,12 +12,47 @@ namespace unforge
 		public String FileName { get => this.StreamReader.ReadTextAtOffset(this.FileNameOffset); }
 		public DataForgeStructDefinition StructDefinition { get => this.StreamReader.ReadStructDefinitionAtIndex(this.StructIndex); }
 
+		/// <summary>
+		/// Sanitizes a string to be a valid XML element name.
+		/// Replaces invalid characters with underscores.
+		/// </summary>
+		private static String SanitizeXmlName(String name)
+		{
+			if (String.IsNullOrEmpty(name)) return "_";
+
+			var sb = new StringBuilder(name.Length);
+
+			for (int i = 0; i < name.Length; i++)
+			{
+				char c = name[i];
+
+				// First character must be letter or underscore
+				if (i == 0)
+				{
+					if (Char.IsLetter(c) || c == '_')
+						sb.Append(c);
+					else
+						sb.Append('_');
+				}
+				// Subsequent characters can be letters, digits, hyphens, underscores, periods
+				else
+				{
+					if (Char.IsLetterOrDigit(c) || c == '_' || c == '-' || c == '.')
+						sb.Append(c);
+					else
+						sb.Append('_');
+				}
+			}
+
+			return sb.ToString();
+		}
 
 		public XmlElement ReadAsXml(XmlNode xmlNode = null)
 		{
 			// Ensure top level node for record
-			if (xmlNode is XmlDocument xmlDocument) xmlNode = xmlDocument.CreateElement(this.Name);
-			else if (xmlNode is XmlElement xmlRoot) xmlNode = xmlRoot.OwnerDocument.CreateElement(this.Name);
+			var sanitizedName = SanitizeXmlName(this.Name);
+			if (xmlNode is XmlDocument xmlDocument) xmlNode = xmlDocument.CreateElement(sanitizedName);
+			else if (xmlNode is XmlElement xmlRoot) xmlNode = xmlRoot.OwnerDocument.CreateElement(sanitizedName);
 
 			var xmlElement = xmlNode as XmlElement;
 			

--- a/src/unforge/ComplexTypes/DataForgeStructDefinition.cs
+++ b/src/unforge/ComplexTypes/DataForgeStructDefinition.cs
@@ -164,12 +164,6 @@ namespace unforge
 							var dataStruct = this.StreamReader.ReadStructDefinitionAtIndex(pointer.StructIndex);
 
 							return parentNode.CreateElementWithValue(nameOverride ?? propertyDefinition.Name, String.Format("{1}[{2:X4}]", propertyDefinition.DataType, dataStruct.Name, pointer.VariantIndex, pointer.Padding));
-
-							var result = this.StreamReader.ReadStructAtIndexAsXml(parentNode.OwnerDocument.CreateElement(dataStruct.Name), pointer.StructIndex, pointer.VariantIndex);
-
-							if (result != null) return parentNode.CreateElementWithValue(nameOverride ?? propertyDefinition.Name, result);
-
-							return null;
 						}
 					case EDataType.varLocale:
 						{
@@ -195,8 +189,23 @@ namespace unforge
 			}
 			catch (Exception ex)
 			{
+				this.StreamReader.Logger.LogError(
+					message: $"Error reading property value",
+					recordPath: this.StreamReader.CurrentRecordPath,
+					propertyName: propertyDefinition.Name,
+					dataType: propertyDefinition.DataType.ToString(),
+					streamPosition: this.StreamReader.Position,
+					exception: ex);
+
 				return parentNode.CreateAttributeWithValue(nameOverride ?? propertyDefinition.Name, $"Error reading property {propertyDefinition.Name} of type {propertyDefinition.DataType}: {ex}");
 			}
+
+			this.StreamReader.Logger.LogWarning(
+				message: $"Unhandled data type encountered",
+				recordPath: this.StreamReader.CurrentRecordPath,
+				propertyName: propertyDefinition.Name,
+				dataType: propertyDefinition.DataType.ToString(),
+				streamPosition: this.StreamReader.Position);
 
 			return parentNode.CreateAttributeWithValue(nameOverride ?? propertyDefinition.Name, $"Unhandled Type {propertyDefinition.DataType}");
 		}
@@ -227,16 +236,20 @@ namespace unforge
 
 					case EDataType.varGuid: return parentNode.CreateElementWithValue($"Guid", this.StreamReader.ReadGuidAtIndex(firstIndex + offset).Value);
 					case EDataType.varReference:
-
-						if (this.StreamReader.FollowReferences)
 						{
 							var dataForgeReference = this.StreamReader.ReadReferenceAtIndex(firstIndex + offset);
-							var xmlNode = this.StreamReader.ReadRecordByReferenceAsXml(parentNode, dataForgeReference.Value);
 
-							if (xmlNode is XmlElement xmlElement) return xmlElement;
+							if (dataForgeReference.IsNull) return null;
+
+							if (this.StreamReader.FollowReferences)
+							{
+								var xmlNode = this.StreamReader.ReadRecordByReferenceAsXml(parentNode, dataForgeReference.Value);
+
+								if (xmlNode is XmlElement xmlElement) return xmlElement;
+							}
+
+							return parentNode.CreateElementWithValue($"Reference", dataForgeReference.Value);
 						}
-
-						return parentNode.CreateElementWithValue($"Reference", this.StreamReader.ReadReferenceAtIndex(firstIndex + offset).Value);
 				
 					case EDataType.varUInt8: return parentNode.CreateElementWithValue($"UInt8", this.StreamReader.ReadUInt8AtIndex(firstIndex + offset).Value);
 					case EDataType.varUInt16: return parentNode.CreateElementWithValue($"UInt16", this.StreamReader.ReadUInt16AtIndex(firstIndex + offset).Value);
@@ -255,6 +268,9 @@ namespace unforge
 					case EDataType.varWeakPointer:
 						{
 							var pointer = this.StreamReader.ReadWeakPointerAtIndex(offset + firstIndex);
+
+							if (pointer.IsNull) return null;
+
 							var dataMapping = this.StreamReader.ReadDataMappingAtIndex(pointer.StructIndex);
 
 							return this.StreamReader.ReadStructAtIndexAsXml(parentNode.OwnerDocument.CreateElement(dataMapping.Name), pointer.StructIndex, pointer.VariantIndex);
@@ -262,6 +278,9 @@ namespace unforge
 					case EDataType.varStrongPointer:
 						{
 							var pointer = this.StreamReader.ReadStrongPointerAtIndex(offset + firstIndex);
+
+							if (pointer.IsNull) return null;
+
 							var dataMapping = this.StreamReader.ReadDataMappingAtIndex(pointer.StructIndex);
 
 							return this.StreamReader.ReadStructAtIndexAsXml(parentNode.OwnerDocument.CreateElement(dataMapping.Name), pointer.StructIndex, pointer.VariantIndex);
@@ -277,8 +296,23 @@ namespace unforge
 			}
 			catch (Exception ex)
 			{
+				this.StreamReader.Logger.LogError(
+					message: $"Error reading array element at index {offset}",
+					recordPath: this.StreamReader.CurrentRecordPath,
+					propertyName: propertyDefinition.Name,
+					dataType: propertyDefinition.DataType.ToString(),
+					streamPosition: this.StreamReader.Position,
+					exception: ex);
+
 				return parentNode.CreateElementWithValue(propertyDefinition.Name, $"Error reading array property {propertyDefinition.Name} of type {propertyDefinition.DataType}: {ex}");
 			}
+
+			this.StreamReader.Logger.LogWarning(
+				message: $"Unhandled array data type at index {offset}",
+				recordPath: this.StreamReader.CurrentRecordPath,
+				propertyName: propertyDefinition.Name,
+				dataType: propertyDefinition.DataType.ToString(),
+				streamPosition: this.StreamReader.Position);
 
 			return parentNode.CreateElementWithValue(propertyDefinition.Name, "TBC");
 		}

--- a/src/unforge/DataForge.cs
+++ b/src/unforge/DataForge.cs
@@ -23,6 +23,16 @@ namespace unforge
 		public static Int32 MaxPointerDepth { get; set; } = 100;
 		public static Int32 MaxNodes { get; set; } = 10000;
 
+		/// <summary>
+		/// Logger instance for capturing extraction errors.
+		/// </summary>
+		public DataForgeLogger Logger { get; } = DataForgeLogger.Instance;
+
+		/// <summary>
+		/// The current record path being processed (for error context).
+		/// </summary>
+		public String CurrentRecordPath { get; internal set; }
+
 		public Int32 FileVersion { get; }
 		public Int64 Length { get => this.BaseStream.Length; }
 		public Int64 Position
@@ -157,7 +167,7 @@ namespace unforge
 			foreach (var dataMappingIndex in Enumerable.Range(0, this.DataMappingCount))
 			{
 				var dataMapping = this.ReadDataMappingAtIndex(dataMappingIndex);
-				var dataStruct = this.ReadStructDefinitionAtIndex(dataMappingIndex);
+				var dataStruct = this.ReadStructDefinitionAtIndex(dataMapping.StructIndex);
 
 				if (!this.StructToDataOffsetMap.ContainsKey(dataMapping.StructIndex)) this.StructToDataOffsetMap[dataMapping.StructIndex] = lastOffset;
 				lastOffset += (Int32)(dataMapping.StructCount * dataStruct.RecordSize);
@@ -780,11 +790,18 @@ namespace unforge
 				this.RecordStack.Add(recordIndex);
 
 				var record = this.ReadRecordDefinitionAtIndex(recordIndex);
+				this.CurrentRecordPath = record.FileName;
 
 				return record.ReadAsXml(xmlNode);
 			}
 			catch (Exception ex)
 			{
+				this.Logger.LogError(
+					message: $"Failed to read record at index {recordIndex}",
+					recordPath: this.CurrentRecordPath,
+					streamPosition: position,
+					exception: ex);
+
 				return xmlNode.CreateElementWithValue("Error", ex.Message);
 			}
 			finally
@@ -841,24 +858,47 @@ namespace unforge
 
 		public void Save(String filename)
 		{
+			this.Logger.LogInfo($"Starting extraction: FileVersion={this.FileVersion}, IsLegacy={this.IsLegacy}, Records={this.RecordDefinitionCount}");
+			this.Logger.LogDebug($"File size: {this.Length} bytes, DataOffset: 0x{this.DataOffset:X8}");
+
+			var recordCount = 0;
+			var errorCount = 0;
+
 			foreach (var fileReference in this.PathToRecordMap.Keys)
 			{
-				var node = this.ReadRecordByPathAsXml(fileReference);
-
-				if (node == null) continue;
-
-				var newPath = Path.Combine(Path.GetDirectoryName(filename), fileReference);
-
-				if (!Directory.Exists(Path.GetDirectoryName(newPath))) Directory.CreateDirectory(Path.GetDirectoryName(newPath));
-
-
-				using (var fileStream= File.OpenWrite(newPath))
-				using (var writer = XmlWriter.Create(fileStream, _xmlSettings))
+				recordCount++;
+				try
 				{
-					node.WriteTo(writer);
-					writer.Flush();
+					var node = this.ReadRecordByPathAsXml(fileReference);
+
+					if (node == null)
+					{
+						this.Logger.LogWarning($"Record returned null", recordPath: fileReference);
+						continue;
+					}
+
+					var newPath = Path.Combine(Path.GetDirectoryName(filename), fileReference);
+
+					if (!Directory.Exists(Path.GetDirectoryName(newPath))) Directory.CreateDirectory(Path.GetDirectoryName(newPath));
+
+					using (var fileStream = File.OpenWrite(newPath))
+					using (var writer = XmlWriter.Create(fileStream, _xmlSettings))
+					{
+						node.WriteTo(writer);
+						writer.Flush();
+					}
+				}
+				catch (Exception ex)
+				{
+					errorCount++;
+					this.Logger.LogError(
+						message: $"Failed to save record",
+						recordPath: fileReference,
+						exception: ex);
 				}
 			}
+
+			this.Logger.LogInfo($"Extraction complete: {recordCount} records processed, {errorCount} save errors");
 		}
 	}
 }

--- a/src/unforge/DataForgeLogger.cs
+++ b/src/unforge/DataForgeLogger.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace unforge
+{
+	/// <summary>
+	/// Logger for capturing DataForge extraction errors and diagnostics.
+	/// </summary>
+	public class DataForgeLogger
+	{
+		public static DataForgeLogger Instance { get; } = new DataForgeLogger();
+
+		public Boolean IsEnabled { get; set; } = false;
+		public Boolean VerboseMode { get; set; } = false;
+
+		private readonly List<LogEntry> _entries = new List<LogEntry>();
+		private readonly Object _lock = new Object();
+
+		public Int32 ErrorCount { get; private set; } = 0;
+		public Int32 WarningCount { get; private set; } = 0;
+
+		public void Clear()
+		{
+			lock (_lock)
+			{
+				_entries.Clear();
+				ErrorCount = 0;
+				WarningCount = 0;
+			}
+		}
+
+		public void LogError(String message, String recordPath = null, String propertyName = null,
+			String dataType = null, Int64? streamPosition = null, Exception exception = null)
+		{
+			if (!IsEnabled) return;
+
+			lock (_lock)
+			{
+				ErrorCount++;
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Error,
+					Timestamp = DateTime.UtcNow,
+					Message = message,
+					RecordPath = recordPath,
+					PropertyName = propertyName,
+					DataType = dataType,
+					StreamPosition = streamPosition,
+					Exception = exception
+				});
+			}
+
+			if (VerboseMode)
+			{
+				Console.Error.WriteLine($"[ERROR] {FormatEntry(_entries[_entries.Count - 1])}");
+			}
+		}
+
+		public void LogWarning(String message, String recordPath = null, String propertyName = null,
+			String dataType = null, Int64? streamPosition = null)
+		{
+			if (!IsEnabled) return;
+
+			lock (_lock)
+			{
+				WarningCount++;
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Warning,
+					Timestamp = DateTime.UtcNow,
+					Message = message,
+					RecordPath = recordPath,
+					PropertyName = propertyName,
+					DataType = dataType,
+					StreamPosition = streamPosition
+				});
+			}
+
+			if (VerboseMode)
+			{
+				Console.Error.WriteLine($"[WARN] {FormatEntry(_entries[_entries.Count - 1])}");
+			}
+		}
+
+		public void LogInfo(String message)
+		{
+			if (!IsEnabled || !VerboseMode) return;
+
+			lock (_lock)
+			{
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Info,
+					Timestamp = DateTime.UtcNow,
+					Message = message
+				});
+			}
+
+			Console.WriteLine($"[INFO] {message}");
+		}
+
+		public void LogDebug(String message, Int64? streamPosition = null)
+		{
+			if (!IsEnabled || !VerboseMode) return;
+
+			lock (_lock)
+			{
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Debug,
+					Timestamp = DateTime.UtcNow,
+					Message = message,
+					StreamPosition = streamPosition
+				});
+			}
+
+			Console.WriteLine($"[DEBUG] {message}");
+		}
+
+		public void SaveToFile(String filePath)
+		{
+			lock (_lock)
+			{
+				var sb = new StringBuilder();
+				sb.AppendLine("=== DataForge Extraction Log ===");
+				sb.AppendLine($"Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
+				sb.AppendLine($"Total Entries: {_entries.Count}");
+				sb.AppendLine($"Errors: {ErrorCount}, Warnings: {WarningCount}");
+				sb.AppendLine(new String('=', 50));
+				sb.AppendLine();
+
+				foreach (var entry in _entries)
+				{
+					sb.AppendLine(FormatEntry(entry));
+					if (entry.Exception != null)
+					{
+						sb.AppendLine($"  Stack Trace: {entry.Exception.StackTrace}");
+					}
+					sb.AppendLine();
+				}
+
+				File.WriteAllText(filePath, sb.ToString());
+			}
+		}
+
+		public String GetSummary()
+		{
+			lock (_lock)
+			{
+				if (ErrorCount == 0 && WarningCount == 0)
+					return "Extraction completed with no errors.";
+
+				return $"Extraction completed with {ErrorCount} error(s) and {WarningCount} warning(s).";
+			}
+		}
+
+		public IReadOnlyList<LogEntry> GetEntries()
+		{
+			lock (_lock)
+			{
+				return _entries.ToArray();
+			}
+		}
+
+		private String FormatEntry(LogEntry entry)
+		{
+			var sb = new StringBuilder();
+			sb.Append($"[{entry.Level}] {entry.Message}");
+
+			if (!String.IsNullOrEmpty(entry.RecordPath))
+				sb.Append($" | Record: {entry.RecordPath}");
+
+			if (!String.IsNullOrEmpty(entry.PropertyName))
+				sb.Append($" | Property: {entry.PropertyName}");
+
+			if (!String.IsNullOrEmpty(entry.DataType))
+				sb.Append($" | Type: {entry.DataType}");
+
+			if (entry.StreamPosition.HasValue)
+				sb.Append($" | Position: 0x{entry.StreamPosition.Value:X8}");
+
+			if (entry.Exception != null)
+				sb.Append($" | Exception: {entry.Exception.GetType().Name}: {entry.Exception.Message}");
+
+			return sb.ToString();
+		}
+
+		public enum LogLevel
+		{
+			Debug,
+			Info,
+			Warning,
+			Error
+		}
+
+		public class LogEntry
+		{
+			public LogLevel Level { get; set; }
+			public DateTime Timestamp { get; set; }
+			public String Message { get; set; }
+			public String RecordPath { get; set; }
+			public String PropertyName { get; set; }
+			public String DataType { get; set; }
+			public Int64? StreamPosition { get; set; }
+			public Exception Exception { get; set; }
+		}
+	}
+}

--- a/src/unp4k/P4kLogger.cs
+++ b/src/unp4k/P4kLogger.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace unp4k
+{
+	/// <summary>
+	/// Logger for capturing P4K extraction errors and diagnostics.
+	/// </summary>
+	public class P4kLogger
+	{
+		public static P4kLogger Instance { get; } = new P4kLogger();
+
+		public Boolean IsEnabled { get; set; } = false;
+		public Boolean VerboseMode { get; set; } = false;
+
+		private readonly List<LogEntry> _entries = new List<LogEntry>();
+		private readonly Object _lock = new Object();
+
+		public Int32 ErrorCount { get; private set; } = 0;
+		public Int32 WarningCount { get; private set; } = 0;
+		public Int32 SuccessCount { get; private set; } = 0;
+		public Int32 SkippedCount { get; private set; } = 0;
+
+		public void Clear()
+		{
+			lock (_lock)
+			{
+				_entries.Clear();
+				ErrorCount = 0;
+				WarningCount = 0;
+				SuccessCount = 0;
+				SkippedCount = 0;
+			}
+		}
+
+		public void LogError(String message, String entryName = null, String compressionMethod = null,
+			Int64? compressedSize = null, Int64? uncompressedSize = null, Exception exception = null)
+		{
+			if (!IsEnabled) return;
+
+			lock (_lock)
+			{
+				ErrorCount++;
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Error,
+					Timestamp = DateTime.UtcNow,
+					Message = message,
+					EntryName = entryName,
+					CompressionMethod = compressionMethod,
+					CompressedSize = compressedSize,
+					UncompressedSize = uncompressedSize,
+					Exception = exception
+				});
+			}
+
+			if (VerboseMode)
+			{
+				Console.Error.WriteLine($"[ERROR] {FormatEntry(_entries[_entries.Count - 1])}");
+			}
+		}
+
+		public void LogWarning(String message, String entryName = null, String compressionMethod = null)
+		{
+			if (!IsEnabled) return;
+
+			lock (_lock)
+			{
+				WarningCount++;
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Warning,
+					Timestamp = DateTime.UtcNow,
+					Message = message,
+					EntryName = entryName,
+					CompressionMethod = compressionMethod
+				});
+			}
+
+			if (VerboseMode)
+			{
+				Console.Error.WriteLine($"[WARN] {FormatEntry(_entries[_entries.Count - 1])}");
+			}
+		}
+
+		public void LogSuccess(String entryName, String compressionMethod, Int64 compressedSize, Int64 uncompressedSize, Boolean isEncrypted)
+		{
+			if (!IsEnabled) return;
+
+			lock (_lock)
+			{
+				SuccessCount++;
+
+				if (VerboseMode)
+				{
+					_entries.Add(new LogEntry
+					{
+						Level = LogLevel.Info,
+						Timestamp = DateTime.UtcNow,
+						Message = "Extracted successfully",
+						EntryName = entryName,
+						CompressionMethod = compressionMethod,
+						CompressedSize = compressedSize,
+						UncompressedSize = uncompressedSize,
+						IsEncrypted = isEncrypted
+					});
+				}
+			}
+		}
+
+		public void LogSkipped(String entryName, String reason)
+		{
+			if (!IsEnabled) return;
+
+			lock (_lock)
+			{
+				SkippedCount++;
+
+				if (VerboseMode)
+				{
+					_entries.Add(new LogEntry
+					{
+						Level = LogLevel.Debug,
+						Timestamp = DateTime.UtcNow,
+						Message = $"Skipped: {reason}",
+						EntryName = entryName
+					});
+				}
+			}
+		}
+
+		public void LogInfo(String message)
+		{
+			if (!IsEnabled || !VerboseMode) return;
+
+			lock (_lock)
+			{
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Info,
+					Timestamp = DateTime.UtcNow,
+					Message = message
+				});
+			}
+
+			Console.WriteLine($"[INFO] {message}");
+		}
+
+		public void LogDebug(String message)
+		{
+			if (!IsEnabled || !VerboseMode) return;
+
+			lock (_lock)
+			{
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Debug,
+					Timestamp = DateTime.UtcNow,
+					Message = message
+				});
+			}
+
+			Console.WriteLine($"[DEBUG] {message}");
+		}
+
+		public void SaveToFile(String filePath)
+		{
+			lock (_lock)
+			{
+				var sb = new StringBuilder();
+				sb.AppendLine("=== P4K Extraction Log ===");
+				sb.AppendLine($"Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
+				sb.AppendLine($"Total Entries: {_entries.Count}");
+				sb.AppendLine($"Extracted: {SuccessCount}, Errors: {ErrorCount}, Warnings: {WarningCount}, Skipped: {SkippedCount}");
+				sb.AppendLine(new String('=', 50));
+				sb.AppendLine();
+
+				// Group errors and warnings at the top for easy review
+				var errors = _entries.FindAll(e => e.Level == LogLevel.Error);
+				var warnings = _entries.FindAll(e => e.Level == LogLevel.Warning);
+
+				if (errors.Count > 0)
+				{
+					sb.AppendLine("=== ERRORS ===");
+					foreach (var entry in errors)
+					{
+						sb.AppendLine(FormatEntry(entry));
+						if (entry.Exception != null)
+						{
+							sb.AppendLine($"  Stack Trace: {entry.Exception.StackTrace}");
+						}
+						sb.AppendLine();
+					}
+				}
+
+				if (warnings.Count > 0)
+				{
+					sb.AppendLine("=== WARNINGS ===");
+					foreach (var entry in warnings)
+					{
+						sb.AppendLine(FormatEntry(entry));
+						sb.AppendLine();
+					}
+				}
+
+				File.WriteAllText(filePath, sb.ToString());
+			}
+		}
+
+		public String GetSummary()
+		{
+			lock (_lock)
+			{
+				var total = SuccessCount + ErrorCount + SkippedCount;
+				if (ErrorCount == 0 && WarningCount == 0)
+					return $"Extraction completed: {SuccessCount} files extracted, {SkippedCount} skipped, no errors.";
+
+				return $"Extraction completed: {SuccessCount} files extracted, {SkippedCount} skipped, {ErrorCount} error(s), {WarningCount} warning(s).";
+			}
+		}
+
+		public IReadOnlyList<LogEntry> GetEntries()
+		{
+			lock (_lock)
+			{
+				return _entries.ToArray();
+			}
+		}
+
+		private String FormatEntry(LogEntry entry)
+		{
+			var sb = new StringBuilder();
+			sb.Append($"[{entry.Level}] {entry.Message}");
+
+			if (!String.IsNullOrEmpty(entry.EntryName))
+				sb.Append($" | File: {entry.EntryName}");
+
+			if (!String.IsNullOrEmpty(entry.CompressionMethod))
+				sb.Append($" | Compression: {entry.CompressionMethod}");
+
+			if (entry.CompressedSize.HasValue && entry.UncompressedSize.HasValue)
+				sb.Append($" | Size: {entry.CompressedSize} -> {entry.UncompressedSize}");
+
+			if (entry.IsEncrypted.HasValue)
+				sb.Append($" | Encrypted: {entry.IsEncrypted}");
+
+			if (entry.Exception != null)
+				sb.Append($" | Exception: {entry.Exception.GetType().Name}: {entry.Exception.Message}");
+
+			return sb.ToString();
+		}
+
+		public enum LogLevel
+		{
+			Debug,
+			Info,
+			Warning,
+			Error
+		}
+
+		public class LogEntry
+		{
+			public LogLevel Level { get; set; }
+			public DateTime Timestamp { get; set; }
+			public String Message { get; set; }
+			public String EntryName { get; set; }
+			public String CompressionMethod { get; set; }
+			public Int64? CompressedSize { get; set; }
+			public Int64? UncompressedSize { get; set; }
+			public Boolean? IsEncrypted { get; set; }
+			public Exception Exception { get; set; }
+		}
+	}
+}

--- a/src/unp4k/Program.cs
+++ b/src/unp4k/Program.cs
@@ -2,7 +2,7 @@
 using ICSharpCode.SharpZipLib.Zip;
 using System;
 using System.IO;
-using System.Net.Http;
+using System.Linq;
 
 namespace unp4k
 {
@@ -12,27 +12,58 @@ namespace unp4k
 		{
 			var key = new Byte[] { 0x5E, 0x7A, 0x20, 0x02, 0x30, 0x2E, 0xEB, 0x1A, 0x3B, 0xB6, 0x17, 0xC3, 0x0F, 0xDE, 0x1E, 0x47 };
 
-			if (args.Length == 0) args = new[] { @"Data.p4k" };
+			// Parse command-line options
+			var verbose = args.Any(a => a == "-v" || a == "--verbose");
+			var logToFile = args.Any(a => a == "-l" || a == "--log");
+			var inputArgs = args.Where(a => !a.StartsWith("-")).ToArray();
 
-			if (args.Length == 1) args = new[] { args[0], "*.*" };
+			// Configure logging
+			P4kLogger.Instance.IsEnabled = true;
+			P4kLogger.Instance.VerboseMode = verbose;
 
-			using (var pakFile = File.OpenRead(args[0]))
+			if (inputArgs.Length == 0) inputArgs = new[] { @"Data.p4k" };
+
+			if (inputArgs.Length == 1) inputArgs = new[] { inputArgs[0], "*.*" };
+
+			var p4kPath = inputArgs[0];
+			var filter = inputArgs[1];
+
+			if (!File.Exists(p4kPath))
+			{
+				Console.WriteLine($"Error: File not found: {p4kPath}");
+				Console.WriteLine();
+				PrintUsage();
+				return;
+			}
+
+			P4kLogger.Instance.LogInfo($"Opening P4K archive: {p4kPath}");
+			P4kLogger.Instance.LogInfo($"Filter: {filter}");
+
+			using (var pakFile = File.OpenRead(p4kPath))
 			{
 				var pak = new ZipFile(pakFile) { Key = key };
 				byte[] buf = new byte[4096];
 
+				P4kLogger.Instance.LogInfo($"Archive contains {pak.Count} entries");
+
+				var totalEntries = 0;
+
 				foreach (ZipEntry entry in pak)
 				{
+					totalEntries++;
 					try
 					{
 						var crypto = entry.IsAesCrypted ? "Crypt" : "Plain";
+						var normalizedFilter = filter;
 
-						if (args[1].StartsWith("*.")) args[1] = args[1].Substring(1);                                                                                           // Enable *.ext format for extensions
+						if (normalizedFilter.StartsWith("*.")) normalizedFilter = normalizedFilter.Substring(1);  // Enable *.ext format for extensions
 
-						if (args[1] == ".*" ||                                                                                                                                  // Searching for everything
-							args[1] == "*" ||                                                                                                                                   // Searching for everything
-							entry.Name.ToLowerInvariant().Contains(args[1].ToLowerInvariant()) ||                                                                               // Searching for keywords / extensions
-							(args[1].EndsWith("xml", StringComparison.InvariantCultureIgnoreCase) && entry.Name.EndsWith(".dcb", StringComparison.InvariantCultureIgnoreCase))) // Searching for XMLs - include game.dcb
+						var shouldExtract = normalizedFilter == ".*" ||                                                                                              // Searching for everything
+							normalizedFilter == "*" ||                                                                                                               // Searching for everything
+							entry.Name.ToLowerInvariant().Contains(normalizedFilter.ToLowerInvariant()) ||                                                           // Searching for keywords / extensions
+							(normalizedFilter.EndsWith("xml", StringComparison.InvariantCultureIgnoreCase) && entry.Name.EndsWith(".dcb", StringComparison.InvariantCultureIgnoreCase)); // Searching for XMLs - include game.dcb
+
+						if (shouldExtract)
 						{
 							var target = new FileInfo(entry.Name);
 
@@ -50,44 +81,91 @@ namespace unp4k
 									}
 								}
 
-								// target.Delete();
+								// Verify extraction
+								var extractedFile = new FileInfo(entry.Name);
+								if (extractedFile.Exists)
+								{
+									if (extractedFile.Length != entry.Size && entry.Size > 0)
+									{
+										P4kLogger.Instance.LogWarning(
+											message: $"Size mismatch: expected {entry.Size}, got {extractedFile.Length}",
+											entryName: entry.Name,
+											compressionMethod: entry.CompressionMethod.ToString());
+									}
+
+									P4kLogger.Instance.LogSuccess(
+										entryName: entry.Name,
+										compressionMethod: entry.CompressionMethod.ToString(),
+										compressedSize: entry.CompressedSize,
+										uncompressedSize: entry.Size,
+										isEncrypted: entry.IsAesCrypted);
+								}
+								else
+								{
+									P4kLogger.Instance.LogError(
+										message: "File was not created after extraction",
+										entryName: entry.Name,
+										compressionMethod: entry.CompressionMethod.ToString());
+								}
 							}
+							else
+							{
+								P4kLogger.Instance.LogSkipped(entry.Name, "File already exists");
+							}
+						}
+						else
+						{
+							P4kLogger.Instance.LogSkipped(entry.Name, "Does not match filter");
 						}
 					}
 					catch (Exception ex)
 					{
 						Console.WriteLine($"Exception while extracting {entry.Name}: {ex.Message}");
 
-						try
-						{
-							using (var client = new HttpClient { })
-							{
-								// var server = "http://herald.holoxplor.local";
-								var server = "https://herald.holoxplor.space";
-
-								client.DefaultRequestHeaders.Add("client", "unp4k");
-
-								using (var content = new MultipartFormDataContent("UPLOAD----"))
-								{
-									content.Add(new StringContent($"{ex.Message}\r\n\r\n{ex.StackTrace}"), "exception", entry.Name);
-
-									using (var errorReport = client.PostAsync($"{server}/p4k/exception/{entry.Name}", content).Result)
-									{
-										if (errorReport.StatusCode == System.Net.HttpStatusCode.OK)
-										{
-											Console.WriteLine("This exception has been reported.");
-										}
-									}
-								}
-							}
-						}
-						catch (Exception)
-						{
-							Console.WriteLine("There was a problem whilst attempting to report this error.");
-						}
+						P4kLogger.Instance.LogError(
+							message: "Exception during extraction",
+							entryName: entry.Name,
+							compressionMethod: entry.CompressionMethod.ToString(),
+							compressedSize: entry.CompressedSize,
+							uncompressedSize: entry.Size,
+							exception: ex);
 					}
 				}
+
+				P4kLogger.Instance.LogInfo($"Processed {totalEntries} entries");
 			}
+
+			// Output summary
+			Console.WriteLine();
+			Console.WriteLine(P4kLogger.Instance.GetSummary());
+
+			// Save log file if requested
+			if (logToFile)
+			{
+				var logPath = Path.ChangeExtension(p4kPath, "log");
+				P4kLogger.Instance.SaveToFile(logPath);
+				Console.WriteLine($"Log saved to: {logPath}");
+			}
+		}
+
+		static void PrintUsage()
+		{
+			Console.WriteLine("Usage: unp4k.exe [options] <p4k-file> [filter]");
+			Console.WriteLine();
+			Console.WriteLine("Options:");
+			Console.WriteLine("  -v, --verbose     Enable verbose output (show all operations)");
+			Console.WriteLine("  -l, --log         Write extraction log to file (p4k-file.log)");
+			Console.WriteLine();
+			Console.WriteLine("Arguments:");
+			Console.WriteLine("  <p4k-file>        Path to the .p4k archive file");
+			Console.WriteLine("  [filter]          Optional filter (default: *.* for all files)");
+			Console.WriteLine("                    Examples: *.xml, *.dcb, Data/*, weapon");
+			Console.WriteLine();
+			Console.WriteLine("Examples:");
+			Console.WriteLine("  unp4k.exe Data.p4k                    Extract all files");
+			Console.WriteLine("  unp4k.exe Data.p4k *.xml              Extract XML files (includes .dcb)");
+			Console.WriteLine("  unp4k.exe -l Data.p4k *.xml           Extract with logging");
+			Console.WriteLine("  unp4k.exe -v -l Data.p4k              Verbose extraction with log");
 		}
 	}
 }

--- a/src/unsocpak/Program.cs
+++ b/src/unsocpak/Program.cs
@@ -1,0 +1,229 @@
+using ICSharpCode.SharpZipLib.Core;
+using ICSharpCode.SharpZipLib.Zip;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace unsocpak
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+			Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
+			// Parse command-line options
+			var verbose = args.Any(a => a == "-v" || a == "--verbose");
+			var logToFile = args.Any(a => a == "-l" || a == "--log");
+			var overwrite = args.Any(a => a == "-o" || a == "--overwrite");
+			var inputArgs = args.Where(a => !a.StartsWith("-")).ToArray();
+
+			// Configure logging
+			SocpakLogger.Instance.IsEnabled = true;
+			SocpakLogger.Instance.VerboseMode = verbose;
+
+			if (inputArgs.Length == 0)
+			{
+				PrintUsage();
+				return;
+			}
+
+			var inputPath = inputArgs[0];
+
+			// Collect all socpak files to process
+			var socpakFiles = CollectSocpakFiles(inputPath);
+
+			if (socpakFiles.Length == 0)
+			{
+				Console.WriteLine($"No .socpak files found matching: {inputPath}");
+				return;
+			}
+
+			Console.WriteLine($"Found {socpakFiles.Length} .socpak file(s) to extract");
+			SocpakLogger.Instance.LogInfo($"Found {socpakFiles.Length} socpak files");
+
+			var counter = 0;
+
+			foreach (var socpakFile in socpakFiles)
+			{
+				counter++;
+				var percentComplete = (int)Math.Round((double)counter / socpakFiles.Length * 100);
+
+				try
+				{
+					var outputDir = Path.GetDirectoryName(socpakFile);
+					if (String.IsNullOrEmpty(outputDir))
+						outputDir = Directory.GetCurrentDirectory();
+
+					Console.Write($"\r[{percentComplete,3}%] Extracting: {Path.GetFileName(socpakFile)}".PadRight(80));
+
+					var entriesExtracted = ExtractSocpak(socpakFile, outputDir, overwrite);
+
+					SocpakLogger.Instance.LogSuccess(socpakFile, entriesExtracted);
+
+					if (verbose)
+					{
+						Console.WriteLine();
+						Console.WriteLine($"  -> Extracted {entriesExtracted} entries to {outputDir}");
+					}
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine();
+					Console.WriteLine($"Error extracting {socpakFile}: {ex.Message}");
+
+					SocpakLogger.Instance.LogError(
+						message: "Exception during extraction",
+						socpakFile: socpakFile,
+						exception: ex);
+				}
+			}
+
+			Console.WriteLine();
+			Console.WriteLine();
+			Console.WriteLine(SocpakLogger.Instance.GetSummary());
+
+			// Save log file if requested
+			if (logToFile)
+			{
+				var logPath = Path.Combine(
+					Path.GetDirectoryName(socpakFiles[0]) ?? Directory.GetCurrentDirectory(),
+					"unsocpak.log");
+				SocpakLogger.Instance.SaveToFile(logPath);
+				Console.WriteLine($"Log saved to: {logPath}");
+			}
+		}
+
+		static String[] CollectSocpakFiles(String inputPath)
+		{
+			// Check if it's a specific file
+			if (File.Exists(inputPath))
+			{
+				if (inputPath.EndsWith(".socpak", StringComparison.OrdinalIgnoreCase))
+				{
+					return new[] { Path.GetFullPath(inputPath) };
+				}
+				Console.WriteLine($"Warning: {inputPath} is not a .socpak file");
+				return Array.Empty<String>();
+			}
+
+			// Check if it's a directory
+			if (Directory.Exists(inputPath))
+			{
+				return Directory.GetFiles(inputPath, "*.socpak", SearchOption.AllDirectories)
+					.Select(Path.GetFullPath)
+					.ToArray();
+			}
+
+			// Check if it's a glob pattern
+			var directory = Path.GetDirectoryName(inputPath);
+			var pattern = Path.GetFileName(inputPath);
+
+			if (String.IsNullOrEmpty(directory))
+				directory = Directory.GetCurrentDirectory();
+
+			if (!Directory.Exists(directory))
+			{
+				Console.WriteLine($"Directory not found: {directory}");
+				return Array.Empty<String>();
+			}
+
+			// If pattern is *.socpak or similar, use it directly
+			if (pattern.Contains("*") || pattern.Contains("?"))
+			{
+				return Directory.GetFiles(directory, pattern, SearchOption.AllDirectories)
+					.Where(f => f.EndsWith(".socpak", StringComparison.OrdinalIgnoreCase))
+					.Select(Path.GetFullPath)
+					.ToArray();
+			}
+
+			// Otherwise treat as directory search
+			return Directory.GetFiles(directory, "*.socpak", SearchOption.AllDirectories)
+				.Select(Path.GetFullPath)
+				.ToArray();
+		}
+
+		static Int32 ExtractSocpak(String socpakPath, String outputDir, Boolean overwrite)
+		{
+			var entriesExtracted = 0;
+			var buffer = new byte[4096];
+
+			using (var fs = File.OpenRead(socpakPath))
+			using (var zipStream = new ZipInputStream(fs))
+			{
+				ZipEntry entry;
+				while ((entry = zipStream.GetNextEntry()) != null)
+				{
+					try
+					{
+						// Skip directory entries (entries ending with / or with no name)
+						if (entry.IsDirectory || String.IsNullOrEmpty(entry.Name))
+							continue;
+
+						var destinationPath = Path.Combine(outputDir, entry.Name);
+						var destinationDir = Path.GetDirectoryName(destinationPath);
+
+						// Ensure the directory exists
+						if (!String.IsNullOrEmpty(destinationDir) && !Directory.Exists(destinationDir))
+						{
+							Directory.CreateDirectory(destinationDir);
+						}
+
+						// Check if file exists
+						if (File.Exists(destinationPath))
+						{
+							if (overwrite)
+							{
+								File.Delete(destinationPath);
+							}
+							else
+							{
+								SocpakLogger.Instance.LogSkipped(socpakPath, $"File exists: {entry.Name}");
+								continue;
+							}
+						}
+
+						using (var outputStream = File.Create(destinationPath))
+						{
+							StreamUtils.Copy(zipStream, outputStream, buffer);
+						}
+						entriesExtracted++;
+					}
+					catch (Exception ex)
+					{
+						SocpakLogger.Instance.LogWarning(
+							message: $"Failed to extract entry: {ex.Message} | Stack: {ex.StackTrace}",
+							socpakFile: socpakPath,
+							entryName: entry.Name);
+					}
+				}
+			}
+
+			return entriesExtracted;
+		}
+
+		static void PrintUsage()
+		{
+			Console.WriteLine("unsocpak - Star Citizen .socpak extractor");
+			Console.WriteLine();
+			Console.WriteLine("Usage: unsocpak.exe [options] <path>");
+			Console.WriteLine();
+			Console.WriteLine("Options:");
+			Console.WriteLine("  -v, --verbose     Enable verbose output (show all operations)");
+			Console.WriteLine("  -l, --log         Write extraction log to file (unsocpak.log)");
+			Console.WriteLine("  -o, --overwrite   Overwrite existing files (default: skip)");
+			Console.WriteLine();
+			Console.WriteLine("Arguments:");
+			Console.WriteLine("  <path>            Path to .socpak file, directory, or glob pattern");
+			Console.WriteLine();
+			Console.WriteLine("Examples:");
+			Console.WriteLine("  unsocpak.exe file.socpak              Extract single file");
+			Console.WriteLine("  unsocpak.exe *.socpak                 Extract all socpak files in current dir");
+			Console.WriteLine("  unsocpak.exe /path/to/dir             Extract all socpak files recursively");
+			Console.WriteLine("  unsocpak.exe -v -o /path/to/dir       Verbose with overwrite");
+		}
+	}
+}

--- a/src/unsocpak/SocpakLogger.cs
+++ b/src/unsocpak/SocpakLogger.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace unsocpak
+{
+	/// <summary>
+	/// Logger for capturing socpak extraction errors and diagnostics.
+	/// </summary>
+	public class SocpakLogger
+	{
+		public static SocpakLogger Instance { get; } = new SocpakLogger();
+
+		public Boolean IsEnabled { get; set; } = false;
+		public Boolean VerboseMode { get; set; } = false;
+
+		private readonly List<LogEntry> _entries = new List<LogEntry>();
+		private readonly Object _lock = new Object();
+
+		public Int32 ErrorCount { get; private set; } = 0;
+		public Int32 WarningCount { get; private set; } = 0;
+		public Int32 SuccessCount { get; private set; } = 0;
+		public Int32 SkippedCount { get; private set; } = 0;
+
+		public void Clear()
+		{
+			lock (_lock)
+			{
+				_entries.Clear();
+				ErrorCount = 0;
+				WarningCount = 0;
+				SuccessCount = 0;
+				SkippedCount = 0;
+			}
+		}
+
+		public void LogError(String message, String socpakFile = null, String entryName = null, Exception exception = null)
+		{
+			if (!IsEnabled) return;
+
+			lock (_lock)
+			{
+				ErrorCount++;
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Error,
+					Timestamp = DateTime.UtcNow,
+					Message = message,
+					SocpakFile = socpakFile,
+					EntryName = entryName,
+					Exception = exception
+				});
+			}
+
+			if (VerboseMode)
+			{
+				Console.Error.WriteLine($"[ERROR] {FormatEntry(_entries[_entries.Count - 1])}");
+			}
+		}
+
+		public void LogWarning(String message, String socpakFile = null, String entryName = null)
+		{
+			if (!IsEnabled) return;
+
+			lock (_lock)
+			{
+				WarningCount++;
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Warning,
+					Timestamp = DateTime.UtcNow,
+					Message = message,
+					SocpakFile = socpakFile,
+					EntryName = entryName
+				});
+			}
+
+			if (VerboseMode)
+			{
+				Console.Error.WriteLine($"[WARN] {FormatEntry(_entries[_entries.Count - 1])}");
+			}
+		}
+
+		public void LogSuccess(String socpakFile, Int32 entriesExtracted)
+		{
+			if (!IsEnabled) return;
+
+			lock (_lock)
+			{
+				SuccessCount++;
+
+				if (VerboseMode)
+				{
+					_entries.Add(new LogEntry
+					{
+						Level = LogLevel.Info,
+						Timestamp = DateTime.UtcNow,
+						Message = $"Extracted {entriesExtracted} entries",
+						SocpakFile = socpakFile
+					});
+				}
+			}
+		}
+
+		public void LogSkipped(String socpakFile, String reason)
+		{
+			if (!IsEnabled) return;
+
+			lock (_lock)
+			{
+				SkippedCount++;
+
+				if (VerboseMode)
+				{
+					_entries.Add(new LogEntry
+					{
+						Level = LogLevel.Debug,
+						Timestamp = DateTime.UtcNow,
+						Message = $"Skipped: {reason}",
+						SocpakFile = socpakFile
+					});
+				}
+			}
+		}
+
+		public void LogInfo(String message)
+		{
+			if (!IsEnabled || !VerboseMode) return;
+
+			lock (_lock)
+			{
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Info,
+					Timestamp = DateTime.UtcNow,
+					Message = message
+				});
+			}
+
+			Console.WriteLine($"[INFO] {message}");
+		}
+
+		public void LogDebug(String message)
+		{
+			if (!IsEnabled || !VerboseMode) return;
+
+			lock (_lock)
+			{
+				_entries.Add(new LogEntry
+				{
+					Level = LogLevel.Debug,
+					Timestamp = DateTime.UtcNow,
+					Message = message
+				});
+			}
+
+			Console.WriteLine($"[DEBUG] {message}");
+		}
+
+		public void SaveToFile(String filePath)
+		{
+			lock (_lock)
+			{
+				var sb = new StringBuilder();
+				sb.AppendLine("=== Socpak Extraction Log ===");
+				sb.AppendLine($"Generated: {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
+				sb.AppendLine($"Total Entries: {_entries.Count}");
+				sb.AppendLine($"Extracted: {SuccessCount}, Errors: {ErrorCount}, Warnings: {WarningCount}, Skipped: {SkippedCount}");
+				sb.AppendLine(new String('=', 50));
+				sb.AppendLine();
+
+				// Group errors and warnings at the top for easy review
+				var errors = _entries.FindAll(e => e.Level == LogLevel.Error);
+				var warnings = _entries.FindAll(e => e.Level == LogLevel.Warning);
+
+				if (errors.Count > 0)
+				{
+					sb.AppendLine("=== ERRORS ===");
+					foreach (var entry in errors)
+					{
+						sb.AppendLine(FormatEntry(entry));
+						if (entry.Exception != null)
+						{
+							sb.AppendLine($"  Stack Trace: {entry.Exception.StackTrace}");
+						}
+						sb.AppendLine();
+					}
+				}
+
+				if (warnings.Count > 0)
+				{
+					sb.AppendLine("=== WARNINGS ===");
+					foreach (var entry in warnings)
+					{
+						sb.AppendLine(FormatEntry(entry));
+						sb.AppendLine();
+					}
+				}
+
+				File.WriteAllText(filePath, sb.ToString());
+			}
+		}
+
+		public String GetSummary()
+		{
+			lock (_lock)
+			{
+				if (ErrorCount == 0 && WarningCount == 0)
+					return $"Extraction completed: {SuccessCount} socpak files extracted, {SkippedCount} skipped, no errors.";
+
+				return $"Extraction completed: {SuccessCount} socpak files extracted, {SkippedCount} skipped, {ErrorCount} error(s), {WarningCount} warning(s).";
+			}
+		}
+
+		public IReadOnlyList<LogEntry> GetEntries()
+		{
+			lock (_lock)
+			{
+				return _entries.ToArray();
+			}
+		}
+
+		private String FormatEntry(LogEntry entry)
+		{
+			var sb = new StringBuilder();
+			sb.Append($"[{entry.Level}] {entry.Message}");
+
+			if (!String.IsNullOrEmpty(entry.SocpakFile))
+				sb.Append($" | Socpak: {entry.SocpakFile}");
+
+			if (!String.IsNullOrEmpty(entry.EntryName))
+				sb.Append($" | Entry: {entry.EntryName}");
+
+			if (entry.Exception != null)
+				sb.Append($" | Exception: {entry.Exception.GetType().Name}: {entry.Exception.Message}");
+
+			return sb.ToString();
+		}
+
+		public enum LogLevel
+		{
+			Debug,
+			Info,
+			Warning,
+			Error
+		}
+
+		public class LogEntry
+		{
+			public LogLevel Level { get; set; }
+			public DateTime Timestamp { get; set; }
+			public String Message { get; set; }
+			public String SocpakFile { get; set; }
+			public String EntryName { get; set; }
+			public Exception Exception { get; set; }
+		}
+	}
+}

--- a/src/unsocpak/unsocpak.csproj
+++ b/src/unsocpak/unsocpak.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+		<LangVersion>Latest</LangVersion>
+		<PlatformTarget>AnyCPU</PlatformTarget>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+		<OutputType>Exe</OutputType>
+		<StartupObject>unsocpak.Program</StartupObject>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
+		<Optimize>False</Optimize>
+		<DebugType>full</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<DefineConstants>TRACE;DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)'=='Release'">
+		<Optimize>True</Optimize>
+		<DebugType>none</DebugType>
+		<DebugSymbols>false</DebugSymbols>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Release|net10.0'">
+		<PublishSingleFile>true</PublishSingleFile>
+		<SelfContained>true</SelfContained>
+		<PublishTrimmed>false</PublishTrimmed>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\ICSharpCode.SharpZipLib\ICSharpCode.SharpZipLib.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/unp4k.sln
+++ b/unp4k.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unp4k.fs", "src\unp4k.fs\un
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unforge.cli", "src\unforge.cli\unforge.cli.csproj", "{5C5AC242-F745-4052-88AB-3383048069EC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unsocpak", "src\unsocpak\unsocpak.csproj", "{CFB6F995-793A-47E2-90BD-B4C60B6C7C87}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +54,10 @@ Global
 		{5C5AC242-F745-4052-88AB-3383048069EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5C5AC242-F745-4052-88AB-3383048069EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C5AC242-F745-4052-88AB-3383048069EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFB6F995-793A-47E2-90BD-B4C60B6C7C87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFB6F995-793A-47E2-90BD-B4C60B6C7C87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFB6F995-793A-47E2-90BD-B4C60B6C7C87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFB6F995-793A-47E2-90BD-B4C60B6C7C87}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hi @peter-dolkens,

First of all, thank you for creating this tool, was very helpful for me.

I've worked on some changes for my personal use of your application and I would like to share them with you, you can decide if you want to integrate them completely or partially, it's up to you.

- Add structured logging system (DataForgeLogger, P4kLogger, SocpakLogger) with verbose mode, log-to-file support, and extraction summaries
- Fix DataForge struct offset calculation using dataMapping.StructIndex instead of loop index
- Add null pointer checks for references, weak pointers, and strong pointers to prevent crashes
- Sanitize XML element names to handle invalid characters in record names
- Remove unreachable code after return statement in varClass case
- Add new unsocpak tool for batch extraction of .socpak files with progress reporting
- Update CLI tools with -v/--verbose and -l/--log options
- Document unsocpak usage in README

The unsocpak its just a tool to extract socpak files faster than creating a script using 7z or any other zip tool.
I hope my changes are of help for some other users.