### PR TITLE
Add support for DataForge v8 format

### DIFF
--- a/src/unforge/ComplexTypes/DataForgeRecordDefinition.cs
+++ b/src/unforge/ComplexTypes/DataForgeRecordDefinition.cs
@@ -30,6 +30,10 @@ namespace unforge
 			xmlElement.AddAttribute("__type", this.StructDefinition.Name);
 			xmlElement.AddAttribute("__ref", this.Hash);
 			xmlElement.AddAttribute("__path", this.FileName);
+			if (this.StreamReader.FileVersion >= 8)
+			{
+				xmlElement.AddAttribute("__team", this.DevTeamName);
+			}
 			// }
 
 			return xmlElement;

--- a/src/unforge/ComplexTypes/DataForgeRecordDefinition.cs
+++ b/src/unforge/ComplexTypes/DataForgeRecordDefinition.cs
@@ -9,6 +9,7 @@ namespace unforge
 	{
 		public String Name { get => this.StreamReader.ReadBlobAtOffset(this.NameOffset); }
 		public String FileName { get => this.StreamReader.ReadTextAtOffset(this.FileNameOffset); }
+		public String DevTeamName { get => this.StreamReader.ReadBlobAtOffset(this.DevTeamNameOffset); }
 		public DataForgeStructDefinition StructDefinition { get => this.StreamReader.ReadStructDefinitionAtIndex(this.StructIndex); }
 
 
@@ -35,9 +36,11 @@ namespace unforge
 		}
 
 		public static Int32 RecordSizeInBytes = 32;
+		public static Int32 RecordSizeInBytesV8 = 36;
 
 		public UInt32 NameOffset { get; }
 		public UInt32 FileNameOffset { get; }
+		public UInt32 DevTeamNameOffset { get; }
 
 		public String __structIndex { get { return String.Format("{0:X4}", this.StructIndex); } }
 		public UInt32 StructIndex { get; }
@@ -57,6 +60,11 @@ namespace unforge
 			if (!this.StreamReader.IsLegacy)
 			{
 				this.FileNameOffset = this.StreamReader.ReadUInt32();
+			}
+
+			if (this.StreamReader.FileVersion >= 8)
+			{
+				this.DevTeamNameOffset = this.StreamReader.ReadUInt32();
 			}
 
 			this.StructIndex = this.StreamReader.ReadUInt32();

--- a/src/unforge/DataForge.cs
+++ b/src/unforge/DataForge.cs
@@ -66,7 +66,7 @@ namespace unforge
 		public Int64 EnumDefinitionOffset { get => this.PropertyDefinitionOffset + this.PropertyDefinitionCount * DataForgePropertyDefinition.RecordSizeInBytes; }
 		public Int64 DataMappingOffset { get => this.EnumDefinitionOffset + this.EnumDefinitionCount * DataForgeEnumDefinition.RecordSizeInBytes; }
 		public Int64 RecordDefinitionOffset { get => this.DataMappingOffset + this.DataMappingCount * (this.IsLegacy ? DataForgeDataMapping.RecordSizeInBytes : DataForgeDataMapping.RecordSizeInBytesV6); }
-		public Int64 Int8ValueOffset { get => this.RecordDefinitionOffset + this.RecordDefinitionCount * DataForgeRecordDefinition.RecordSizeInBytes; }
+		public Int64 Int8ValueOffset { get => this.RecordDefinitionOffset + this.RecordDefinitionCount * (this.FileVersion < 8 ? DataForgeRecordDefinition.RecordSizeInBytes : DataForgeRecordDefinition.RecordSizeInBytesV8); }
 		public Int64 Int16ValueOffset { get => this.Int8ValueOffset + this.Int8ValueCount * DataForgeInt8.RecordSizeInBytes; }
 		public Int64 Int32ValueOffset { get => this.Int16ValueOffset + this.Int16ValueCount * DataForgeInt16.RecordSizeInBytes; }
 		public Int64 Int64ValueOffset { get => this.Int32ValueOffset + this.Int32ValueCount * DataForgeInt32.RecordSizeInBytes; }
@@ -143,7 +143,7 @@ namespace unforge
 
 			foreach (var recordIndex in Enumerable.Range(0, this.RecordDefinitionCount))
 			{
-				this.Position = this.RecordDefinitionOffset + recordIndex * DataForgeRecordDefinition.RecordSizeInBytes;
+				this.Position = this.RecordDefinitionOffset + recordIndex * (this.FileVersion < 8 ? DataForgeRecordDefinition.RecordSizeInBytes : DataForgeRecordDefinition.RecordSizeInBytesV8);
 				var record = DataForgeRecordDefinition.ReadFromStream(this);
 
 				var filename = record.FileName;
@@ -247,7 +247,7 @@ namespace unforge
 
 			try
 			{
-				this.Position = this.RecordDefinitionOffset + index * DataForgeRecordDefinition.RecordSizeInBytes;
+				this.Position = this.RecordDefinitionOffset + index * (this.FileVersion < 8 ? DataForgeRecordDefinition.RecordSizeInBytes : DataForgeRecordDefinition.RecordSizeInBytesV8);
 
 				return DataForgeRecordDefinition.ReadFromStream(this);
 			}


### PR DESCRIPTION
DataForge v8 adds a uint32 field to the Record Definitions, right after the file name offset.

This seems to be another string offset for lookup in the second string table. Values suggest they are internal dev team or group names, possibly the owners of the record. I have named the attribute accordingly but it is of course just a preliminary guess.

For the format detection I've tried to follow the example from `DataForgeDataMapping` which changed in v6.

- In `DataForgeRecordDefinition` added `RecordSizeInBytesV8`, `DevTeamNameOffset`, and `DevTeamName`.
  - Offset is read after the file name offset if `FileVersion` is at least 8.
  - String is read from the second string table (blob).
- In `DataForge` updated various index and offset calculations to use either `RecordSizeInBytes` or `RecordSizeInBytesV8` based on `FileVersion`.
- Added the `DevTeamName` to XML output as the __team attribute.