### PR TITLE
Skip reading of pointers with invalid/maxint index values

### DIFF
--- a/src/unforge/ComplexTypes/DataForgeStructDefinition.cs
+++ b/src/unforge/ComplexTypes/DataForgeStructDefinition.cs
@@ -255,6 +255,8 @@ namespace unforge
 					case EDataType.varWeakPointer:
 						{
 							var pointer = this.StreamReader.ReadWeakPointerAtIndex(offset + firstIndex);
+							if (pointer.StructIndex == 0xFFFFFFFF) return null;
+							
 							var dataMapping = this.StreamReader.ReadDataMappingAtIndex(pointer.StructIndex);
 
 							return this.StreamReader.ReadStructAtIndexAsXml(parentNode.OwnerDocument.CreateElement(dataMapping.Name), pointer.StructIndex, pointer.VariantIndex);
@@ -262,6 +264,8 @@ namespace unforge
 					case EDataType.varStrongPointer:
 						{
 							var pointer = this.StreamReader.ReadStrongPointerAtIndex(offset + firstIndex);
+							if (pointer.StructIndex == 0xFFFFFFFF) return null;
+
 							var dataMapping = this.StreamReader.ReadDataMappingAtIndex(pointer.StructIndex);
 
 							return this.StreamReader.ReadStructAtIndexAsXml(parentNode.OwnerDocument.CreateElement(dataMapping.Name), pointer.StructIndex, pointer.VariantIndex);
@@ -269,6 +273,8 @@ namespace unforge
 					case EDataType.varClass:
 						{
 							var structIndex = (UInt32)(propertyDefinition.Index);
+							if (propertyDefinition.Index == 0xFFFF) return null;
+
 							var dataMapping = this.StreamReader.ReadDataMappingAtIndex(structIndex);
 
 							return this.StreamReader.ReadStructAtIndexAsXml(parentNode.OwnerDocument.CreateElement(dataMapping.Name), propertyDefinition.Index, firstIndex + offset);


### PR DESCRIPTION
Add checks for pointers with index values of 4294967295 aka uint32_max. This appears to be a sentinel value for a "blank or invalid" pointer.

These checks were present in the old file parsing code in unforge 3.x to filter out the associated XML element in those cases (eg https://github.com/dolkensp/unp4k/blob/5c481117124c93b336f87eb57780b246bb8438b6/src/unforge/DataForge.cs#L277 and others).

Fixes dolkensp/unp4k#77