### PR TITLE
Pre-load DataForge tables and value arrays for 23x Save() speedup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build / Run
+
+This is a .NET solution. All projects multi-target `net6.0;net8.0;net10.0`; the release pipeline (`.github/workflows/release.yaml`) builds against `net10.0`. There are no automated tests in this repo.
+
+```pwsh
+dotnet restore
+dotnet build unp4k.sln -c Release
+# Single-file self-contained publish (matches CI):
+dotnet publish src\unp4k\unp4k.csproj          -c Release -r win-x64 -f net10.0
+dotnet publish src\unp4k.fs\unp4k.fs.csproj    -c Release -r win-x64 -f net10.0
+dotnet publish src\unforge.cli\unforge.cli.csproj -c Release -r win-x64 -f net10.0
+```
+
+Linux builds **must** pass `--no-self-contained -p:UseAppHost=false -p:PublishSingleFile=false` and skip `unp4k.fs` (Dokan is Windows-only) — see the matrix in `.github/workflows/release.yaml`.
+
+`appveyor.yml` is legacy (targets `net47`, `master` branch, AppVeyor). The active CI is GitHub Actions on `main`.
+
+## Architecture
+
+Six projects, layered roughly: SharpZipLib (fork) → unforge (library) → unp4k / unp4k.fs / unforge.cli (executables).
+
+- **`src/unp4k`** — Console extractor. Opens a `.p4k` as an encrypted Zip via the SharpZipLib fork and streams entries to disk under the cwd. Filter is a substring match, not a glob (`*.ext` is special-cased to mean `.ext`). Catches per-entry exceptions and POSTs them to `https://herald.holoxplor.space/p4k/exception/...` — this is intentional telemetry, not stray code.
+- **`src/unp4k.fs`** — Mounts a `.p4k` or `.dcb` as a read-only virtual drive via Dokan (`DokanNet` 2.3.0.3). Builds an in-memory `VirtualNode` tree once at startup; `CompressedFileSystem` walks the zip entries (and recurses into any `.dcb` it finds), `DataForgeFileSystem` walks DataForge record paths. CryXML and DataForge records are converted to XML lazily on read via `GetContent` lambdas. The interactive console adjusts `DataForge.MaxReferenceDepth` / `MaxPointerDepth` / `MaxNodes` (statics on `unforge.DataForge`) and clears the VFS cache on change. **Windows-only** — Dokan must be installed on the host.
+- **`src/unforge`** — Library. Two formats live here:
+  - **DataForge** (`DataForge.cs`, `DataForgeTypeReader.cs`, `ComplexTypes/`, `SimpleTypes/`) — bespoke binary DB found inside `.p4k` as `game.dcb`. The on-disk layout (header, definition tables, value arrays, two string tables) is documented in `spec.md` at the repo root; consult it before touching the reader. `FileVersion` and `IsLegacy` gate field widths and which tables exist. Static `Max*` knobs guard against recursion blowups when records reference each other.
+  - **CryXML** (`CryXmlB/`) — CryEngine's serialized XML; `CryXmlSerializer.ReadFile` returns a real `XmlDocument`.
+- **`src/unforge.cli`** — Wraps `unforge` as a CLI. `Smelter` dispatches by extension: `.dcb` → `DataForge.Save(...xml)`, anything else → `CryXmlSerializer.ReadFile`, with the original renamed to `.raw` when not overwriting.
+- **`src/ICSharpCode.SharpZipLib`** — Local fork, **not** the NuGet package. The fork adds Star Citizen's AES decryption to the Zip reader; `ZipFile.Key` takes the 16-byte key. Both executables hardcode the same key (`unp4k/Program.cs:13`, `unp4k.fs/Program.cs:175`) — keep them in sync if it ever rotates.
+- **`src/Zstd.Net`** — Zstd bindings. In the solution but **not currently referenced** by any executable; SC's ZSTD entries are decoded through the SharpZipLib fork. Don't assume it's wired up.
+
+## Conventions
+
+- `.editorconfig` mandates **tabs** with `indent_size = 4` for C# (2 for `.csproj`/XML). Match the existing tab-indented style.
+- `DebugType=none` in Release on every project — don't expect PDBs in release output; the CI scripts also explicitly strip any that slip through.

--- a/src/unforge.cli/Program.cs
+++ b/src/unforge.cli/Program.cs
@@ -75,7 +75,10 @@ namespace unforge.cli
 					if (Path.GetExtension(path) == ".dcb")
 					{
 						using var fileStream = File.OpenRead(path);
+						var ctorSw = System.Diagnostics.Stopwatch.StartNew();
 						var df = new DataForge(fileStream);
+						ctorSw.Stop();
+						Console.WriteLine($"DataForge ctor (header + tables): {ctorSw.Elapsed.TotalSeconds:F2}s");
 						df.Save(Path.ChangeExtension(path, "xml"));
 					}
 					else

--- a/src/unforge/DataForge.cs
+++ b/src/unforge/DataForge.cs
@@ -141,23 +141,27 @@ namespace unforge
 
 			// this.ReportOffsets();
 
-			foreach (var recordIndex in Enumerable.Range(0, this.RecordDefinitionCount))
-			{
-				this.Position = this.RecordDefinitionOffset + recordIndex * (this.FileVersion < 8 ? DataForgeRecordDefinition.RecordSizeInBytes : DataForgeRecordDefinition.RecordSizeInBytesV8);
-				var record = DataForgeRecordDefinition.ReadFromStream(this);
+			// Pre-load string tables, definition tables and value arrays once
+			// from the file. After this point, every per-record read is an
+			// array lookup (no stream seek+read+restore per element).
+			this.PreloadStringTables();
+			this.PreloadDefinitionTables();
+			this.PreloadValueArrays();
 
-				var filename = record.FileName;
-				this.PathToRecordMap[filename] = recordIndex;
+			for (Int32 recordIndex = 0; recordIndex < this.RecordDefinitionCount; recordIndex++)
+			{
+				var record = this._recordDefinitions[recordIndex];
+				this.PathToRecordMap[record.FileName] = recordIndex;
 				this.ReferenceToRecordMap[record.Hash] = recordIndex;
 			}
 
 			var lastOffset = 0;
 
 			this.StructToDataOffsetMap = new Dictionary<UInt32, Int64> { };
-			foreach (var dataMappingIndex in Enumerable.Range(0, this.DataMappingCount))
+			for (Int32 dataMappingIndex = 0; dataMappingIndex < this.DataMappingCount; dataMappingIndex++)
 			{
-				var dataMapping = this.ReadDataMappingAtIndex(dataMappingIndex);
-				var dataStruct = this.ReadStructDefinitionAtIndex(dataMappingIndex);
+				var dataMapping = this._dataMappings[dataMappingIndex];
+				var dataStruct = this._structDefinitions[dataMappingIndex];
 
 				if (!this.StructToDataOffsetMap.ContainsKey(dataMapping.StructIndex)) this.StructToDataOffsetMap[dataMapping.StructIndex] = lastOffset;
 				lastOffset += (Int32)(dataMapping.StructCount * dataStruct.RecordSize);
@@ -181,81 +185,205 @@ namespace unforge
 		/// </summary>
 		public Dictionary<UInt32, Int64> StructToDataOffsetMap { get; }
 
+		// Pre-loaded string tables — read once at ctor time so per-record
+		// string lookups become byte-buffer scans instead of stream seeks.
+		private Byte[] _textBuffer;
+		private Byte[] _blobBuffer;
+
+		// Pre-loaded definition tables — read once at ctor time so per-record
+		// reads become array lookups instead of stream seek+read+restore.
+		private DataForgeStructDefinition[] _structDefinitions;
+		private DataForgePropertyDefinition[] _propertyDefinitions;
+		private DataForgeEnumDefinition[] _enumDefinitions;
+		private DataForgeDataMapping[] _dataMappings;
+		private DataForgeRecordDefinition[] _recordDefinitions;
+
+		// Pre-loaded value arrays — same rationale.
+		private DataForgeBoolean[] _booleanValues;
+		private DataForgeInt8[] _int8Values;
+		private DataForgeInt16[] _int16Values;
+		private DataForgeInt32[] _int32Values;
+		private DataForgeInt64[] _int64Values;
+		private DataForgeUInt8[] _uint8Values;
+		private DataForgeUInt16[] _uint16Values;
+		private DataForgeUInt32[] _uint32Values;
+		private DataForgeUInt64[] _uint64Values;
+		private DataForgeSingle[] _singleValues;
+		private DataForgeDouble[] _doubleValues;
+		private DataForgeGuid[] _guidValues;
+		private DataForgeStringLookup[] _stringValues;
+		private DataForgeLocale[] _localeValues;
+		private DataForgeEnum[] _enumValues;
+		private DataForgePointer[] _strongPointerValues;
+		private DataForgePointer[] _weakPointerValues;
+		private DataForgeReference[] _referenceValues;
+		private DataForgeEnum[] _enumOptions;
+
+		private void PreloadStringTables()
+		{
+			this.Position = this.TextOffset;
+			this._textBuffer = new Byte[this.TextLength];
+			ReadFully(this.BaseStream, this._textBuffer);
+
+			if (!this.IsLegacy && this.BlobLength > 0)
+			{
+				this.Position = this.BlobOffset;
+				this._blobBuffer = new Byte[this.BlobLength];
+				ReadFully(this.BaseStream, this._blobBuffer);
+			}
+			else
+			{
+				// Legacy files reuse the text table as their blob table.
+				this._blobBuffer = this._textBuffer;
+			}
+		}
+
+		// Stream.ReadExactly is .NET 7+. We multi-target net6.0 so use a
+		// portable loop. FileStream typically returns the full buffer in a
+		// single Read() for hot files, so this is one iteration in practice.
+		private static void ReadFully(Stream stream, Byte[] buffer)
+		{
+			Int32 total = 0;
+			while (total < buffer.Length)
+			{
+				Int32 read = stream.Read(buffer, total, buffer.Length - total);
+				if (read == 0) throw new EndOfStreamException("Unexpected end of stream while preloading.");
+				total += read;
+			}
+		}
+
+		private void PreloadDefinitionTables()
+		{
+			this.Position = this.StructDefinitionOffset;
+			this._structDefinitions = new DataForgeStructDefinition[this.StructDefinitionCount];
+			for (Int32 i = 0; i < this.StructDefinitionCount; i++) this._structDefinitions[i] = DataForgeStructDefinition.ReadFromStream(this);
+
+			this.Position = this.PropertyDefinitionOffset;
+			this._propertyDefinitions = new DataForgePropertyDefinition[this.PropertyDefinitionCount];
+			for (Int32 i = 0; i < this.PropertyDefinitionCount; i++) this._propertyDefinitions[i] = DataForgePropertyDefinition.ReadFromStream(this);
+
+			this.Position = this.EnumDefinitionOffset;
+			this._enumDefinitions = new DataForgeEnumDefinition[this.EnumDefinitionCount];
+			for (Int32 i = 0; i < this.EnumDefinitionCount; i++) this._enumDefinitions[i] = DataForgeEnumDefinition.ReadFromStream(this);
+
+			this.Position = this.DataMappingOffset;
+			this._dataMappings = new DataForgeDataMapping[this.DataMappingCount];
+			for (Int32 i = 0; i < this.DataMappingCount; i++) this._dataMappings[i] = DataForgeDataMapping.ReadFromStream(this);
+
+			this.Position = this.RecordDefinitionOffset;
+			this._recordDefinitions = new DataForgeRecordDefinition[this.RecordDefinitionCount];
+			for (Int32 i = 0; i < this.RecordDefinitionCount; i++) this._recordDefinitions[i] = DataForgeRecordDefinition.ReadFromStream(this);
+		}
+
+		private void PreloadValueArrays()
+		{
+			this.Position = this.Int8ValueOffset;
+			this._int8Values = new DataForgeInt8[this.Int8ValueCount];
+			for (Int32 i = 0; i < this.Int8ValueCount; i++) this._int8Values[i] = DataForgeInt8.ReadFromStream(this);
+
+			this.Position = this.Int16ValueOffset;
+			this._int16Values = new DataForgeInt16[this.Int16ValueCount];
+			for (Int32 i = 0; i < this.Int16ValueCount; i++) this._int16Values[i] = DataForgeInt16.ReadFromStream(this);
+
+			this.Position = this.Int32ValueOffset;
+			this._int32Values = new DataForgeInt32[this.Int32ValueCount];
+			for (Int32 i = 0; i < this.Int32ValueCount; i++) this._int32Values[i] = DataForgeInt32.ReadFromStream(this);
+
+			this.Position = this.Int64ValueOffset;
+			this._int64Values = new DataForgeInt64[this.Int64ValueCount];
+			for (Int32 i = 0; i < this.Int64ValueCount; i++) this._int64Values[i] = DataForgeInt64.ReadFromStream(this);
+
+			this.Position = this.UInt8ValueOffset;
+			this._uint8Values = new DataForgeUInt8[this.UInt8ValueCount];
+			for (Int32 i = 0; i < this.UInt8ValueCount; i++) this._uint8Values[i] = DataForgeUInt8.ReadFromStream(this);
+
+			this.Position = this.UInt16ValueOffset;
+			this._uint16Values = new DataForgeUInt16[this.UInt16ValueCount];
+			for (Int32 i = 0; i < this.UInt16ValueCount; i++) this._uint16Values[i] = DataForgeUInt16.ReadFromStream(this);
+
+			this.Position = this.UInt32ValueOffset;
+			this._uint32Values = new DataForgeUInt32[this.UInt32ValueCount];
+			for (Int32 i = 0; i < this.UInt32ValueCount; i++) this._uint32Values[i] = DataForgeUInt32.ReadFromStream(this);
+
+			this.Position = this.UInt64ValueOffset;
+			this._uint64Values = new DataForgeUInt64[this.UInt64ValueCount];
+			for (Int32 i = 0; i < this.UInt64ValueCount; i++) this._uint64Values[i] = DataForgeUInt64.ReadFromStream(this);
+
+			this.Position = this.BooleanValueOffset;
+			this._booleanValues = new DataForgeBoolean[this.BooleanValueCount];
+			for (Int32 i = 0; i < this.BooleanValueCount; i++) this._booleanValues[i] = DataForgeBoolean.ReadFromStream(this);
+
+			this.Position = this.SingleValueOffset;
+			this._singleValues = new DataForgeSingle[this.SingleValueCount];
+			for (Int32 i = 0; i < this.SingleValueCount; i++) this._singleValues[i] = DataForgeSingle.ReadFromStream(this);
+
+			this.Position = this.DoubleValueOffset;
+			this._doubleValues = new DataForgeDouble[this.DoubleValueCount];
+			for (Int32 i = 0; i < this.DoubleValueCount; i++) this._doubleValues[i] = DataForgeDouble.ReadFromStream(this);
+
+			this.Position = this.GuidValueOffset;
+			this._guidValues = new DataForgeGuid[this.GuidValueCount];
+			for (Int32 i = 0; i < this.GuidValueCount; i++) this._guidValues[i] = DataForgeGuid.ReadFromStream(this);
+
+			this.Position = this.StringValueOffset;
+			this._stringValues = new DataForgeStringLookup[this.StringValueCount];
+			for (Int32 i = 0; i < this.StringValueCount; i++) this._stringValues[i] = DataForgeStringLookup.ReadFromStream(this);
+
+			this.Position = this.LocaleValueOffset;
+			this._localeValues = new DataForgeLocale[this.LocaleValueCount];
+			for (Int32 i = 0; i < this.LocaleValueCount; i++) this._localeValues[i] = DataForgeLocale.ReadFromStream(this);
+
+			this.Position = this.EnumValueOffset;
+			this._enumValues = new DataForgeEnum[this.EnumValueCount];
+			for (Int32 i = 0; i < this.EnumValueCount; i++) this._enumValues[i] = DataForgeEnum.ReadFromStream(this);
+
+			this.Position = this.StrongValueOffset;
+			this._strongPointerValues = new DataForgePointer[this.StrongValueCount];
+			for (Int32 i = 0; i < this.StrongValueCount; i++) this._strongPointerValues[i] = DataForgePointer.ReadFromStream(this);
+
+			this.Position = this.WeakValueOffset;
+			this._weakPointerValues = new DataForgePointer[this.WeakValueCount];
+			for (Int32 i = 0; i < this.WeakValueCount; i++) this._weakPointerValues[i] = DataForgePointer.ReadFromStream(this);
+
+			this.Position = this.ReferenceValueOffset;
+			this._referenceValues = new DataForgeReference[this.ReferenceValueCount];
+			for (Int32 i = 0; i < this.ReferenceValueCount; i++) this._referenceValues[i] = DataForgeReference.ReadFromStream(this);
+
+			this.Position = this.EnumOptionOffset;
+			this._enumOptions = new DataForgeEnum[this.EnumOptionCount];
+			for (Int32 i = 0; i < this.EnumOptionCount; i++) this._enumOptions[i] = DataForgeEnum.ReadFromStream(this);
+		}
+
 		internal String ReadEnumAtOffset(UInt32 enumValueOffset) => this.ReadTextAtOffset(enumValueOffset);
 
 		internal String ReadTextAtOffset(Int64 offset)
 		{
 			if (offset > this.TextLength) throw new IndexOutOfRangeException($"Offset {offset} is out of range for Text values (length: {this.TextLength})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.TextOffset + offset;
-
-				return this.ReadCString();
-			}
-			finally
-			{
-				this.Position = position;
-			}
+			return ReadCStringFrom(this._textBuffer, (Int32)offset);
 		}
 
 		internal String ReadBlobAtOffset(Int64 offset)
 		{
 			if (this.FileVersion < 6) return this.ReadTextAtOffset(offset);
-
-			if (offset > this.BlobLength) throw new IndexOutOfRangeException($"Offset {offset} is out of range for Blob values (length: {this.TextLength})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.BlobOffset + offset;
-
-				return this.ReadCString();
-			}
-			finally
-			{
-				this.Position = position;
-			}
+			if (offset > this.BlobLength) throw new IndexOutOfRangeException($"Offset {offset} is out of range for Blob values (length: {this.BlobLength})");
+			return ReadCStringFrom(this._blobBuffer, (Int32)offset);
 		}
 
-		internal DataForgeDataMapping ReadDataMappingAtIndex(Int64 index)
+		// Scan a null-terminated string out of the pre-loaded text/blob buffer.
+		// Matches the original byte→char cast (Latin-1) so string output is
+		// byte-identical to the prior ReadCString() path.
+		private static String ReadCStringFrom(Byte[] buffer, Int32 offset)
 		{
-			if (index > this.DataMappingCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Data Mapping values (count: {this.DataMappingCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.DataMappingOffset + index * (this.IsLegacy ? DataForgeDataMapping.RecordSizeInBytes : DataForgeDataMapping.RecordSizeInBytesV6);
-
-				return DataForgeDataMapping.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
+			Int32 end = offset;
+			while (end < buffer.Length && buffer[end] != 0) end++;
+			Int32 length = end - offset;
+			if (length == 0) return String.Empty;
+			return Encoding.Latin1.GetString(buffer, offset, length);
 		}
 
-		internal DataForgeRecordDefinition ReadRecordDefinitionAtIndex(Int64 index)
-		{
-			if (index > this.RecordDefinitionCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Record Definition values (count: {this.RecordDefinitionCount})");
+		internal DataForgeDataMapping ReadDataMappingAtIndex(Int64 index) => this._dataMappings[index];
 
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.RecordDefinitionOffset + index * (this.FileVersion < 8 ? DataForgeRecordDefinition.RecordSizeInBytes : DataForgeRecordDefinition.RecordSizeInBytesV8);
-
-				return DataForgeRecordDefinition.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
+		internal DataForgeRecordDefinition ReadRecordDefinitionAtIndex(Int64 index) => this._recordDefinitions[index];
 
 		public List<(UInt32, UInt32)> StructStack { get; set; } = new List<(UInt32, UInt32)> { };
 
@@ -311,442 +439,49 @@ namespace unforge
 			return xmlNode;
 		}
 
-		internal DataForgeStructDefinition ReadStructDefinitionAtIndex(Int64 index)
-		{
-			if (index > this.StructDefinitionCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Struct Definition values (count: {this.StructDefinitionCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.StructDefinitionOffset + index * DataForgeStructDefinition.RecordSizeInBytes;
-
-				return DataForgeStructDefinition.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgePropertyDefinition ReadPropertyDefinitionAtIndex(Int64 index)
-		{
-			if (index > this.PropertyDefinitionCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Property Definition values (count: {this.PropertyDefinitionCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.PropertyDefinitionOffset + index * DataForgePropertyDefinition.RecordSizeInBytes;
-
-				return DataForgePropertyDefinition.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeBoolean ReadBooleanAtIndex(Int64 index)
-		{
-			if (index > this.BooleanValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Boolean values (count: {this.BooleanValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.BooleanValueOffset + index * DataForgeBoolean.RecordSizeInBytes;
-
-				return DataForgeBoolean.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeDouble ReadDoubleAtIndex(Int64 index)
-		{
-			if (index > this.DoubleValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Double values (count: {this.DoubleValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.DoubleValueOffset + index * DataForgeDouble.RecordSizeInBytes;
-
-				return DataForgeDouble.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeEnum ReadEnumOptionAtIndex(Int64 index)
-		{
-			if (index > this.EnumValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Enum values (count: {this.EnumOptionCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.EnumOptionOffset + index * DataForgeEnum.RecordSizeInBytes;
-
-				return DataForgeEnum.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeEnumDefinition ReadEnumDefinitionAtIndex(Int64 index)
-		{
-			if (index > this.EnumValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Enum values (count: {this.EnumDefinitionCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.EnumDefinitionOffset + index * DataForgeEnumDefinition.RecordSizeInBytes;
-
-				return DataForgeEnumDefinition.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeEnum ReadEnumValueAtIndex(Int64 index)
-		{
-			if (index > this.EnumValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Enum values (count: {this.EnumValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.EnumValueOffset + index * DataForgeEnum.RecordSizeInBytes;
-
-				return DataForgeEnum.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeGuid ReadGuidAtIndex(Int64 index)
-		{
-			if (index > this.GuidValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Guid values (count: {this.GuidValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.GuidValueOffset + index * DataForgeGuid.RecordSizeInBytes;
-
-				return DataForgeGuid.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeInt16 ReadInt16AtIndex(Int64 index)
-		{
-			if (index > this.Int16ValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Int16 values (count: {this.Int16ValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.Int16ValueOffset + index * DataForgeInt16.RecordSizeInBytes;
-
-				return DataForgeInt16.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeInt32 ReadInt32AtIndex(Int64 index)
-		{
-			if (index > this.Int32ValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Int32 values (count: {this.Int32ValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.Int32ValueOffset + index * DataForgeInt32.RecordSizeInBytes;
-
-				return DataForgeInt32.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeInt64 ReadInt64AtIndex(Int64 index)
-		{
-			if (index > this.Int64ValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Int64 values (count: {this.Int64ValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.Int64ValueOffset + index * DataForgeInt64.RecordSizeInBytes;
-
-				return DataForgeInt64.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeInt8 ReadInt8AtIndex(Int64 index)
-		{
-			if (index > this.Int8ValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Int8 values (count: {this.Int8ValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.Int8ValueOffset + index * DataForgeInt8.RecordSizeInBytes;
-
-				return DataForgeInt8.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeLocale ReadLocaleAtIndex(Int64 index)
-		{
-			if (index > this.LocaleValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Locale values (count: {this.LocaleValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.LocaleValueOffset + index * DataForgeLocale.RecordSizeInBytes;
-
-				return DataForgeLocale.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeReference ReadReferenceAtIndex(Int64 index)
-		{
-			if (index > this.ReferenceValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Reference values (count: {this.ReferenceValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.ReferenceValueOffset + index * DataForgeReference.RecordSizeInBytes;
-
-				return DataForgeReference.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeSingle ReadSingleAtIndex(Int64 index)
-		{
-			if (index > this.SingleValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Single values (count: {this.SingleValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.SingleValueOffset + index * DataForgeSingle.RecordSizeInBytes;
-
-				return DataForgeSingle.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeStringLookup ReadStringAtIndex(Int64 index)
-		{
-			if (index > this.StringValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for String values (count: {this.StringValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.StringValueOffset + index * DataForgeStringLookup.RecordSizeInBytes;
-
-				return DataForgeStringLookup.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeUInt16 ReadUInt16AtIndex(Int64 index)
-		{
-			if (index > this.UInt16ValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for UInt16 values (count: {this.UInt16ValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.UInt16ValueOffset + index * DataForgeUInt16.RecordSizeInBytes;
-
-				return DataForgeUInt16.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeUInt32 ReadUInt32AtIndex(Int64 index)
-		{
-			if (index > this.UInt32ValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for UInt32 values (count: {this.UInt32ValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.UInt32ValueOffset + index * DataForgeUInt32.RecordSizeInBytes;
-
-				return DataForgeUInt32.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeUInt64 ReadUInt64AtIndex(Int64 index)
-		{
-			if (index > this.UInt64ValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for UInt64 values (count: {this.UInt64ValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.UInt64ValueOffset + index * DataForgeUInt64.RecordSizeInBytes;
-
-				return DataForgeUInt64.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgeUInt8 ReadUInt8AtIndex(Int64 index)
-		{
-			if (index > this.UInt8ValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for UInt8 values (count: {this.UInt8ValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.UInt8ValueOffset + index * DataForgeUInt8.RecordSizeInBytes;
-
-				return DataForgeUInt8.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgePointer ReadWeakPointerAtIndex(Int64 index)
-		{
-			if (index > this.WeakValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Weak Pointer values (count: {this.WeakValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.WeakValueOffset + index * DataForgePointer.RecordSizeInBytes;
-
-				return DataForgePointer.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		internal DataForgePointer ReadStrongPointerAtIndex(Int64 index)
-		{
-			if (index > this.StrongValueCount) throw new IndexOutOfRangeException($"Index {index} is out of range for Strong Pointer values (count: {this.StrongValueCount})");
-
-			var position = this.Position;
-
-			try
-			{
-				this.Position = this.StrongValueOffset + index * DataForgePointer.RecordSizeInBytes;
-
-				return DataForgePointer.ReadFromStream(this);
-			}
-			finally
-			{
-				this.Position = position;
-			}
-		}
-
-		private String ReadCString()
-		{
-			// Small, fast stack buffer for typical strings
-			Span<Char> initialBuffer = stackalloc Char[256];
-			Span<Char> buffer = initialBuffer;
-
-			Char[] rented = null;
-			Int32 length = 0;
-
-			try
-			{
-				Int32 value;
-				while ((value = this.BaseStream.ReadByte()) != -1 && value != 0)
-				{
-					// Need more space? Rent a bigger buffer.
-					if (length == buffer.Length)
-					{
-						Int32 newSize = buffer.Length * 2;
-
-						Char[] newRented = ArrayPool<Char>.Shared.Rent(newSize);
-						buffer.CopyTo(newRented);
-
-						rented = newRented;
-						buffer = rented;
-					}
-
-					buffer[length++] = (Char)value;
-				}
-
-				// One String allocation from the final span slice
-				return new String(buffer.Slice(0, length));
-			}
-			finally
-			{
-				if (rented != null)
-				{
-					ArrayPool<Char>.Shared.Return(rented);
-				}
-			}
-		}
+		internal DataForgeStructDefinition ReadStructDefinitionAtIndex(Int64 index) => this._structDefinitions[index];
+
+		internal DataForgePropertyDefinition ReadPropertyDefinitionAtIndex(Int64 index) => this._propertyDefinitions[index];
+
+		internal DataForgeBoolean ReadBooleanAtIndex(Int64 index) => this._booleanValues[index];
+
+		internal DataForgeDouble ReadDoubleAtIndex(Int64 index) => this._doubleValues[index];
+
+		internal DataForgeEnum ReadEnumOptionAtIndex(Int64 index) => this._enumOptions[index];
+
+		internal DataForgeEnumDefinition ReadEnumDefinitionAtIndex(Int64 index) => this._enumDefinitions[index];
+
+		internal DataForgeEnum ReadEnumValueAtIndex(Int64 index) => this._enumValues[index];
+
+		internal DataForgeGuid ReadGuidAtIndex(Int64 index) => this._guidValues[index];
+
+		internal DataForgeInt16 ReadInt16AtIndex(Int64 index) => this._int16Values[index];
+
+		internal DataForgeInt32 ReadInt32AtIndex(Int64 index) => this._int32Values[index];
+
+		internal DataForgeInt64 ReadInt64AtIndex(Int64 index) => this._int64Values[index];
+
+		internal DataForgeInt8 ReadInt8AtIndex(Int64 index) => this._int8Values[index];
+
+		internal DataForgeLocale ReadLocaleAtIndex(Int64 index) => this._localeValues[index];
+
+		internal DataForgeReference ReadReferenceAtIndex(Int64 index) => this._referenceValues[index];
+
+		internal DataForgeSingle ReadSingleAtIndex(Int64 index) => this._singleValues[index];
+
+		internal DataForgeStringLookup ReadStringAtIndex(Int64 index) => this._stringValues[index];
+
+		internal DataForgeUInt16 ReadUInt16AtIndex(Int64 index) => this._uint16Values[index];
+
+		internal DataForgeUInt32 ReadUInt32AtIndex(Int64 index) => this._uint32Values[index];
+
+		internal DataForgeUInt64 ReadUInt64AtIndex(Int64 index) => this._uint64Values[index];
+
+		internal DataForgeUInt8 ReadUInt8AtIndex(Int64 index) => this._uint8Values[index];
+
+		internal DataForgePointer ReadWeakPointerAtIndex(Int64 index) => this._weakPointerValues[index];
+
+		internal DataForgePointer ReadStrongPointerAtIndex(Int64 index) => this._strongPointerValues[index];
 
 		public XmlElement ReadRecordByPathAsXml(String path)
 		{

--- a/src/unforge/DataForge.cs
+++ b/src/unforge/DataForge.cs
@@ -841,24 +841,49 @@ namespace unforge
 
 		public void Save(String filename)
 		{
+			var totalSw = Stopwatch.StartNew();
+			var readSw = new Stopwatch();
+			var writeSw = new Stopwatch();
+			var written = 0;
+			var skipped = 0;
+			Int64 bytesWritten = 0;
+
 			foreach (var fileReference in this.PathToRecordMap.Keys)
 			{
+				readSw.Start();
 				var node = this.ReadRecordByPathAsXml(fileReference);
+				readSw.Stop();
 
-				if (node == null) continue;
+				if (node == null) { skipped++; continue; }
 
 				var newPath = Path.Combine(Path.GetDirectoryName(filename), fileReference);
 
 				if (!Directory.Exists(Path.GetDirectoryName(newPath))) Directory.CreateDirectory(Path.GetDirectoryName(newPath));
 
 
-				using (var fileStream= File.OpenWrite(newPath))
+				writeSw.Start();
+				using (var fileStream = File.OpenWrite(newPath))
 				using (var writer = XmlWriter.Create(fileStream, _xmlSettings))
 				{
 					node.WriteTo(writer);
 					writer.Flush();
+					bytesWritten += fileStream.Length;
 				}
+				writeSw.Stop();
+				written++;
 			}
+
+			totalSw.Stop();
+
+			var perRecRead = written > 0 ? readSw.Elapsed.TotalMilliseconds / written : 0;
+			var perRecWrite = written > 0 ? writeSw.Elapsed.TotalMilliseconds / written : 0;
+			Console.WriteLine();
+			Console.WriteLine("=== unforge Save() timing ===");
+			Console.WriteLine($"  records:    {written} written, {skipped} skipped (null)");
+			Console.WriteLine($"  read+build: {readSw.Elapsed.TotalSeconds,8:F2}s  ({perRecRead:F2} ms/rec)");
+			Console.WriteLine($"  xml write:  {writeSw.Elapsed.TotalSeconds,8:F2}s  ({perRecWrite:F2} ms/rec)");
+			Console.WriteLine($"  output:     {bytesWritten / 1_048_576.0,8:F1} MB");
+			Console.WriteLine($"  total:      {totalSw.Elapsed.TotalSeconds,8:F2}s");
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`DataForge.Save()` on Star Citizen LIVE 4.x `Game2.dcb` (291 MB / 57,837 records) went from **26m 19s → 1m 8s** (23.2× wall-clock). The hot path was a save-Position / seek / read / restore-Position cycle on a single shared `BinaryReader` cursor, repeated for every primitive value, every property name lookup, and every nested struct definition. Across the full file that's millions of cursor round-trips.

This PR pre-loads each fixed-stride table and value array sequentially into a typed array once during the ctor, then collapses every `Read*AtIndex` method to a one-line array indexer. The string tables are loaded into byte buffers and parsed in-memory (Latin-1) instead of per-byte stream reads.

## Performance (LIVE 4.x Game2.dcb, 291 MB / 57,837 records)

| Phase | Before | After | Speedup |
|---|---:|---:|---:|
| `DataForge` ctor | 2.23 s | 0.70 s | 3.2× |
| `Save()` read+build | 1477 s | 41 s | 36.3× |
| `Save()` xml write | 87 s | 23 s | 3.8× |
| **Wall clock** | **1579 s** | **68 s** | **23.2×** |

Per-record read+build: 25.54 ms → 0.70 ms.

## Output verification

SHA256-hashed every output XML in both runs and compared:

- 57,837 / 57,837 records produced in both
- **52,862 files byte-identical**
- **4,975 files** differ in *exception-attribute text only* — these are pre-existing dcb data bugs (null-pointer sentinel `0xFFFFFFFF` in strong-pointer arrays). Both versions fail to dereference; the old per-method bound check emitted `"Index N is out of range for X values (count: Y)"`, .NET's default array OOR message is `"Index was outside the bounds of the array."` Same failed records, same number of error attributes per file, only the exception text differs.
- **Zero non-exception data divergences.**

## Targets

Multi-targets `net6.0;net8.0;net10.0` cleanly. Uses `Encoding.Latin1` (.NET 5+) and a portable `ReadFully` helper because `Stream.ReadExactly` is .NET 7+.

## Commits in this PR

1. `Add CLAUDE.md` — onboarding doc for AI-assisted contributors. Drop if not wanted.
2. `Add timing harness` — `Stopwatch` instrumentation in `Save()` and `Smelter`. Used to produce the table above. Happy to gate behind a flag or drop entirely.
3. `Pre-load DataForge tables...` — the actual perf change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)